### PR TITLE
EON-3007: Use Django 1.9 features and drop django-celery-transactions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ deleting objects in a `Django Simple Elasticsearch`_ search index.
 Requirements
 ------------
 
-* Django 1.4+
+* Django 1.9+
 * `Django Simple Elasticsearch`_ `0.9.16`_
 * `Celery`_ 3.X
 
@@ -22,10 +22,6 @@ Use your favorite Python package manager to install the app from PyPI, e.g.::
 By default a few dependencies will automatically be installed:
 
 - `django-appconf`_ -- An app to gracefully handle application settings.
-
-- `django-celery-transactions`_ -- An app that "holds on to Celery tasks
-  until the current database transaction is committed, avoiding potential
-  race conditions as described in `Celery's user guide`_."
 
 Usage
 -----
@@ -73,5 +69,4 @@ requests.
 .. _`Celery`: http://celeryproject.org/
 .. _`Github issue tracker`: https://github.com/jimjkelly/celery-simple-elasticsearch/issues
 .. _`django-appconf`: http://pypi.python.org/pypi/django-appconf
-.. _`django-celery-transactions`: https://github.com/chrisdoble/django-celery-transactions
 .. _`Celery's user guide`: http://celery.readthedocs.org/en/latest/userguide/tasks.html#database-transactions

--- a/celery_simple_elasticsearch/__init__.py
+++ b/celery_simple_elasticsearch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1'
+__version__ = '0.1.0.1'
 
 
 def version_hook(config):

--- a/celery_simple_elasticsearch/__init__.py
+++ b/celery_simple_elasticsearch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0.2'
+__version__ = '0.1.0.3'
 
 
 def version_hook(config):

--- a/celery_simple_elasticsearch/__init__.py
+++ b/celery_simple_elasticsearch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0.1'
+__version__ = '0.1.0.2'
 
 
 def version_hook(config):

--- a/celery_simple_elasticsearch/__init__.py
+++ b/celery_simple_elasticsearch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0.3'
+__version__ = '0.1.0.4'
 
 
 def version_hook(config):

--- a/celery_simple_elasticsearch/tasks.py
+++ b/celery_simple_elasticsearch/tasks.py
@@ -146,11 +146,13 @@ class CelerySimpleElasticSearchUpdateIndex(Task):
           'using': [settings.CELERY_SIMPLE_ELASTICSEARCH_DEFAULT_ALIAS],
           'workers': settings.CELERY_SIMPLE_ELASTICSEARCH_COMMAND_WORKERS,
           'verbosity': settings.CELERY_SIMPLE_ELASTICSEARCH_COMMAND_VERBOSITY,
+          'no_input': True,
+          'rebuild': True,
         }
         defaults.update(kwargs)
         if apps is None:
             apps = settings.CELERY_SIMPLE_ELASTICSEARCH_COMMAND_APPS
         # Run the update_index management command
         logger.info("Starting update index")
-        call_command('--rebuild', *apps, **defaults)
+        call_command('es_manage', *apps, **defaults)
         logger.info("Finishing update index")

--- a/celery_simple_elasticsearch/tasks.py
+++ b/celery_simple_elasticsearch/tasks.py
@@ -1,8 +1,8 @@
+from celery.utils.log import get_task_logger
+from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
-from django.db.models.loading import get_model
-from django.utils.importlib import import_module
-from celery.utils.log import get_task_logger
+from importlib import import_module
 
 from .conf import settings
 
@@ -67,7 +67,7 @@ class CelerySimpleElasticSearchSignalHandler(Task):
         bits = object_path.split('.')
         app_name = '.'.join(bits[:-1])
         classname = bits[-1]
-        model_class = get_model(app_name, classname)
+        model_class = apps.get_model(app_name, classname)
 
         if model_class is None:
             raise ImproperlyConfigured("Could not load model '%s'." %

--- a/celery_simple_elasticsearch/tasks.py
+++ b/celery_simple_elasticsearch/tasks.py
@@ -29,7 +29,7 @@ class CelerySimpleElasticSearchSignalHandler(Task):
 
     def original_apply_async(self, *args, **kwargs):
         """Shortcut method to reach real implementation
-        of celery.Task.apply_sync
+        of celery.Task.apply_async
         """
         return super(
             CelerySimpleElasticSearchSignalHandler, self

--- a/celery_simple_elasticsearch/utils.py
+++ b/celery_simple_elasticsearch/utils.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 from django.db import connection, transaction
+from importlib import import_module
 
 from .conf import settings
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ classifier =
     Topic :: Utilities
 requires-dist =
     django-appconf>=0.4.1
-    django-celery-transactions>=0.1.2
 
 
 [files]


### PR DESCRIPTION
 Use Django 1.9's on_commit() to record what needs to be re-indexed.

Question: should I just remove the use of _get_celery_settings() and just check for variables on django.conf.settings?